### PR TITLE
Expand important objects inside query

### DIFF
--- a/src/js/clean.js
+++ b/src/js/clean.js
@@ -16,7 +16,7 @@ function(expr, typeIfNoOps) {
 
         // Clean within objects
         else if (expr[key] === Object(expr[key])) {
-            expr[key] = clean(expr[key], true);
+            expr[key] = clean(expr[key], !{query:1, $query:1, $orderby:1, sort:1}[key]);
         }
 
         // Convert other values to a string describing their type


### PR DESCRIPTION
With new versions of mongo, `query` commands may include `query` objects, with `$query` key, that real query fields stored in `$query`.

Also, query command may include `$order_by`, which is also a part of query, and is important in query plan.

Also `findAndModify` command includes `query` and `sort` keys.

So, expand these four special keys in any case (not only when they have a $op).
